### PR TITLE
fixed substring issue for finding nodes in the ssh config

### DIFF
--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -14,7 +14,7 @@ impl Client {
 
         let mut nodes: Vec<Node> = vec![];
         for line in file_contents.split('\n') {
-            if !line.contains('#') && line.starts_with("Hostname") {
+            if !line.contains('#') && line.starts_with("Host") {
                 let s: String = line.replace("  ", "").split(' ').nth(1).unwrap().into();
                 nodes.push(Node::new(s))
             }

--- a/test_files/mock_ssh_config
+++ b/test_files/mock_ssh_config
@@ -1,14 +1,14 @@
-Hostname abc
-    Host 0.0.0.0
+Host abc
+    Hostname 0.0.0.0
     Someotheroption
 
 # Hostname THIS_SHOULD_NOT_SHOW
 #     Host 1.1.1.1O
 
-Hostname def
-    Host 0.0.0.0
+Host def
+    Hostname 0.0.0.0
     Someotheroption
 
-Hostname ghi
-    Host 0.0.0.0
+Host ghi
+    Hostname 0.0.0.0
     Someotheroption


### PR DESCRIPTION
This pr fixes a small bug where `Hostname` was the line identifier instead of `Host`



### Additional tasks

- [x] Tests added

~~- [ ] Documentation for changes provided/changed~~
~~- [ ] Updated CHANGELOG.md~~
