### PR TITLE
[#12] Added a flag to filter nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Added
 
 [[#21](https://github.com/MitchellBerend/docker-manager/issues/21)] Remove implicit sudo call
+[[#12](https://github.com/MitchellBerend/docker-manager/issues/12)] Added a flag to filter nodes
 
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +120,7 @@ dependencies = [
  "clap_complete",
  "futures",
  "openssh",
+ "regex",
  "tokio",
 ]
 
@@ -440,6 +450,23 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ tokio = { version = "1.21", features = ["full"] }
 
 clap_complete = "4.0"
 futures = "0.3"
+regex = "1.6"

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ to support all docker commands on remote nodes.
 
 `-s`/`--sudo` Enables sudo on the remote node. This might be needed depending on
 how the remote node and it's user is set up.
+
+`-r`/`--regex` Lets the user supply a regex pattern that filters the nodes after
+they are read in from `~/.ssh/config`.

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -7,6 +7,10 @@ pub struct App {
     #[arg(short, long)]
     pub sudo: bool,
 
+    /// Filters nodes on a given patterns
+    #[arg(short, long, value_name = "regex")]
+    pub regex: Option<String>,
+
     /// This command will be ran on the remote nodes
     #[command(subcommand)]
     pub command: Command,

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -206,8 +206,15 @@ mod tests {
 
     #[test]
     fn test_from_config_regex() {
-        let client = Client::from_config("test_files/mock_ssh_config_regex", Some("regex_pattern.*".into()));
-        let correct_nodes: Vec<String> = vec!["regex_pattern".into(), "regex_patterndef".into(), "regex_patternghi".into()];
+        let client = Client::from_config(
+            "test_files/mock_ssh_config_regex",
+            Some("regex_pattern.*".into()),
+        );
+        let correct_nodes: Vec<String> = vec![
+            "regex_pattern".into(),
+            "regex_patterndef".into(),
+            "regex_patternghi".into(),
+        ];
 
         let nodes: Vec<String> = client
             .nodes

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -205,6 +205,20 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_regex() {
+        let client = Client::from_config("test_files/mock_ssh_config_regex", Some("regex_pattern.*".into()));
+        let correct_nodes: Vec<String> = vec!["regex_pattern".into(), "regex_patterndef".into(), "regex_patternghi".into()];
+
+        let nodes: Vec<String> = client
+            .nodes
+            .iter()
+            .map(|node| node.address.clone())
+            .collect();
+
+        assert_eq!(correct_nodes, nodes);
+    }
+
+    #[test]
     fn test_client_info() {
         let client = Client::from_config("test_files/mock_ssh_config", Some(".*".into()));
         let correct_nodes: Vec<(String, Node)> = vec![

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -4,20 +4,41 @@ use crate::cli::flags::{ExecFlags, ImagesFlags, LogsFlags, PsFlags};
 use crate::cli::Command;
 use crate::utility::command;
 
+use regex::Regex;
+
 #[derive(Debug)]
 pub struct Client {
     nodes: Vec<Node>,
 }
 
 impl Client {
-    pub fn from_config<A: AsRef<Path>>(config_path: A) -> Self {
+    pub fn from_config<A: AsRef<Path>>(config_path: A, regex: Option<String>) -> Self {
         let file_contents = std::fs::read_to_string(config_path).unwrap_or_else(|_| "".into());
+
+        let _re = match regex {
+            Some(ref pattern) => Regex::new(pattern),
+            None => Regex::new(".*"),
+        };
+
+        let re = match _re {
+            Ok(regex) => regex,
+            Err(e) => {
+                eprintln!(
+                    "Some error has occured while compiling your regex patterns {}\n{}",
+                    regex.unwrap(),
+                    e
+                );
+                std::process::exit(1)
+            }
+        };
 
         let mut nodes: Vec<Node> = vec![];
         for line in file_contents.split('\n') {
             if !line.contains('#') && line.starts_with("Host") {
                 let s: String = line.replace("  ", "").split(' ').nth(1).unwrap().into();
-                nodes.push(Node::new(s))
+                if re.is_match(&s) {
+                    nodes.push(Node::new(s));
+                }
             }
         }
 
@@ -171,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_from_config() {
-        let client = Client::from_config("test_files/mock_ssh_config");
+        let client = Client::from_config("test_files/mock_ssh_config", Some(".*".into()));
         let correct_nodes: Vec<String> = vec!["abc".into(), "def".into(), "ghi".into()];
 
         let nodes: Vec<String> = client
@@ -185,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_client_info() {
-        let client = Client::from_config("test_files/mock_ssh_config");
+        let client = Client::from_config("test_files/mock_ssh_config", Some(".*".into()));
         let correct_nodes: Vec<(String, Node)> = vec![
             (String::from("abc"), Node::new("abc".into())),
             (String::from("def"), Node::new("def".into())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub async fn run() {
         }
 
         _ => {
-            for word in utility::run_command(_cli.command, _cli.sudo).await {
+            for word in utility::run_command(_cli.command, _cli.sudo, _cli.regex).await {
                 match word {
                     Ok(s) => println!("{}", s),
                     Err(e) => println!("{}", e),

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -6,12 +6,16 @@ use crate::cli::Command;
 use crate::client::{Client, Node, NodeError};
 use crate::utility::find_container;
 
-pub async fn run_command(command: Command, sudo: bool) -> Vec<Result<String, CommandError>> {
+pub async fn run_command(
+    command: Command,
+    sudo: bool,
+    regex: Option<String>,
+) -> Vec<Result<String, CommandError>> {
     let config_path = format!(
         "{}/.ssh/config",
         std::env::var("HOME").unwrap_or_else(|_| "/home/root".into())
     );
-    let client = Client::from_config(config_path);
+    let client = Client::from_config(config_path, regex);
 
     match command {
         Command::Completion { shell: _ } => {

--- a/test_files/mock_ssh_config_regex
+++ b/test_files/mock_ssh_config_regex
@@ -1,0 +1,17 @@
+Host regex_pattern
+    Hostname 0.0.0.0
+    Someotheroption
+
+# Hostname THIS_SHOULD_NOT_SHOW
+#     Host 1.1.1.1O
+
+Host regex_patterndef
+    Hostname 0.0.0.0
+    Someotheroption
+
+Host regex_patternghi
+    Hostname 0.0.0.0
+    Someotheroption
+
+Host asdfklasdfasdf
+    Hostname 0.0.0.0


### PR DESCRIPTION
Resolves #21

This pr adds an `-r` flag which lets the user supply a regex pattern. This will filter the nodes before the get passed to the execution command.

### Additional tasks

- [x] Documentation for changes provided/changed
- [x] Tests added
- [x] Updated CHANGELOG.md
