### PR TITLE
Logs command output fix

### DIFF
--- a/src/utility/command.rs
+++ b/src/utility/command.rs
@@ -158,10 +158,10 @@ pub async fn run_logs(
 
         let mut rv: String = format!("{}\n", hostname);
 
-        match output.status.code().unwrap() {
-            0 => rv.push_str(std::str::from_utf8(&output.stdout).unwrap_or("")),
-            _ => rv.push_str(std::str::from_utf8(&output.stderr).unwrap_or("")),
-        };
+        // docker logs prints the logs to standard error so it does not matter if the command
+        // succeeded or not
+        rv.push_str(std::str::from_utf8(&output.stderr).unwrap_or(""));
+
         Ok(rv)
     }
 }


### PR DESCRIPTION
With the refactor all debug printing was removed. The log command used this debug printing to output both stdout and stderr. As docker logs outputs the logs to stderr and the function only passes stdout on command success, the logs are never passed on to the caller.

This fix makes the `run_logs` function return the remote stderr in all cases since thats the only interesting output. 