### PR TITLE
Fixed port field spacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docker-manager"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "clap_complete",

--- a/src/formatter/stdout.rs
+++ b/src/formatter/stdout.rs
@@ -1,7 +1,7 @@
 use defaultdict::DefaultHashMap;
 
 const HOSTNAME: &str = "HOSTNAME";
-const OFFSET: usize = 3;
+const OFFSET: usize = 2;
 
 #[derive(Debug)]
 pub struct Parser {
@@ -18,6 +18,8 @@ impl Parser {
         let mut headers: Vec<String> = vec![];
 
         let mut node: Option<String> = None;
+
+        let re = regex::Regex::new(r"\d").unwrap();
 
         // The arms in this if block only execute the same action, they do check different things.
         #[allow(clippy::if_same_then_else)]
@@ -42,8 +44,17 @@ impl Parser {
                 node = Some(String::from(line))
             } else if let Some(node) = &node {
                 let mut placeholder: Vec<String> = vec![];
-                for item in line.split("  ").filter(|item| !item.is_empty()) {
-                    placeholder.push(String::from(item.trim()));
+                for (index, item) in line.split("  ").filter(|item| !item.is_empty()).enumerate() {
+                    if let Some(header) = headers.get(index) {
+                        if header.contains("PORT") && re.is_match(item) {
+                            placeholder.push(String::from(item.trim()));
+                        } else if header.contains("PORT") && !re.is_match(item) {
+                            placeholder.push(String::new());
+                            placeholder.push(String::from(item.trim()));
+                        } else {
+                            placeholder.push(String::from(item.trim()));
+                        }
+                    }
                 }
                 internal.get_mut(node).push(placeholder);
             }


### PR DESCRIPTION
~~Resolves #PUT_ISSUE_NUMBER_HERE_IF_APPLICABLE~~
Standalone pr

This pr adds a check for the port field when parsing the output of the ps command. If the port field is empty now it adds an empty entry so the port field does not get filled with the name of the container.