### PR TITLE
Added the attach flag to the start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[[#56]](https://github.com/MitchellBerend/docker-manager/pull/56) Added the attach flag to the start command
+
+
 v0.0.7
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "docker-manager"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "clap",
  "clap_complete",

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -175,6 +175,7 @@ pub enum Command {
 
     ///Remove one or more containers
     Rm {
+        /// Container name or id
         container_id: String,
 
         /// Force the removal of a running container (uses SIGKILL)
@@ -188,6 +189,10 @@ pub enum Command {
 
     /// Starts a given container unless 2 or more containers are found on remote nodes
     Start {
+        /// Attach STDOUT/STDERR and forward signals
+        #[arg(short, long)]
+        attach: bool,
+
         /// Container name or id
         container_id: String,
     },

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -182,8 +182,12 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Start { container_id, attach } => {
-                match command::run_start(&self.address, session, sudo, &container_id, attach).await {
+            Command::Start {
+                container_id,
+                attach,
+            } => {
+                match command::run_start(&self.address, session, sudo, &container_id, attach).await
+                {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -182,8 +182,8 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Start { container_id } => {
-                match command::run_start(&self.address, session, sudo, &container_id).await {
+            Command::Start { container_id, attach } => {
+                match command::run_start(&self.address, session, sudo, &container_id, attach).await {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }

--- a/src/utility/command.rs
+++ b/src/utility/command.rs
@@ -292,8 +292,13 @@ pub async fn run_start(
     session: openssh::Session,
     sudo: bool,
     container_id: &str,
+    attatch: bool,
 ) -> Result<String, openssh::Error> {
-    let command = vec!["start", container_id];
+    let mut command = vec!["start", container_id];
+
+    if attatch {
+        command.push("-a");
+    };
 
     let _output = match sudo {
         true => {

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -268,7 +268,7 @@ pub async fn run_command(
                 }
             }
         }
-        Command::Start { container_id } => {
+        Command::Start { container_id, attach } => {
             let node_containers: Vec<(String, String)> =
                 find_container(client, &container_id, sudo, true, identity_file).await;
 
@@ -281,7 +281,7 @@ pub async fn run_command(
                     let node_tuple = node_containers.get(0).unwrap().to_owned();
                     let node = Node::new(node_tuple.1);
                     match node
-                        .run_command(Command::Start { container_id }, sudo, identity_file)
+                        .run_command(Command::Start { container_id, attach }, sudo, identity_file)
                         .await
                     {
                         Ok(s) => vec![Ok(s)],

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -268,7 +268,10 @@ pub async fn run_command(
                 }
             }
         }
-        Command::Start { container_id, attach } => {
+        Command::Start {
+            container_id,
+            attach,
+        } => {
             let node_containers: Vec<(String, String)> =
                 find_container(client, &container_id, sudo, true, identity_file).await;
 
@@ -281,7 +284,14 @@ pub async fn run_command(
                     let node_tuple = node_containers.get(0).unwrap().to_owned();
                     let node = Node::new(node_tuple.1);
                     match node
-                        .run_command(Command::Start { container_id, attach }, sudo, identity_file)
+                        .run_command(
+                            Command::Start {
+                                container_id,
+                                attach,
+                            },
+                            sudo,
+                            identity_file,
+                        )
                         .await
                     {
                         Ok(s) => vec![Ok(s)],


### PR DESCRIPTION
This pr adds the `--attach` flag to the `start` command. This flag was not implemented in #53 on accident.
