### PR TITLE
Added support for passing multiple container_ids to the rm command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+[[#60]](https://github.com/MitchellBerend/docker-manager/pull/60) Added support for removing multiple containers on multiple nodes at once
 
 [[#57]](https://github.com/MitchellBerend/docker-manager/pull/57) Added support for restarting multiple containers on multiple nodes at once
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to support all docker commands on remote nodes.
 | LOGS     |                               |
 | PS       |                               |
 | RESTART  | Multiple containers supported |
-| RM       |                               |
+| RM       | Multiple containers supported |
 | START    |                               |
 | STOP     |                               |
 | SYSTEM   |                               |

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -176,7 +176,7 @@ pub enum Command {
     /// Remove one or more containers
     Rm {
         /// Container name or id
-        container_id: String,
+        container_id: Vec<String>,
 
         /// Force the removal of a running container (uses SIGKILL)
         #[arg(short, long)]

--- a/src/utility/command.rs
+++ b/src/utility/command.rs
@@ -256,10 +256,14 @@ pub async fn run_rm(
     hostname: &str,
     session: openssh::Session,
     sudo: bool,
-    container_id: &str,
+    container_id: &Vec<String>,
     flags: RmFlags,
 ) -> Result<String, openssh::Error> {
-    let mut command = vec!["rm", container_id];
+    let mut command = vec!["rm"];
+
+    for container in container_id {
+        command.push(&container);
+    }
 
     for flag in flags.flags() {
         command.push(flag)


### PR DESCRIPTION
This pr adds support for passing multiple container_ids to the underlying `docker rm` command.


### Additional tasks

- [x] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
