### PR TITLE
Refactored the run_command

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -279,3 +279,361 @@ impl std::fmt::Display for Command {
         }
     }
 }
+
+impl Command {
+    pub fn internal_reference_command(&self) -> InternalCommand {
+        match self {
+            Self::Exec {
+                container_id,
+                command,
+                detach,
+                detach_keys,
+                env,
+                env_file,
+                interactive,
+                privileged,
+                user,
+                workdir,
+            } => {
+                let mut commands: Vec<&str> = vec![];
+                for com in command {
+                    commands.push(com);
+                }
+
+                let mut _env: Option<Vec<&str>> = match env {
+                    Some(environ) => {
+                        let mut int: Vec<&str> = vec![];
+                        for e in environ {
+                            int.push(e);
+                        }
+
+                        Some(int)
+                    }
+                    None => None,
+                };
+
+                let mut _env_file: Option<Vec<&str>> = match env_file {
+                    Some(environ) => {
+                        let mut int: Vec<&str> = vec![];
+                        for e in environ {
+                            int.push(e);
+                        }
+
+                        Some(int)
+                    }
+                    None => None,
+                };
+
+                InternalCommand::Exec {
+                    container_id: &container_id,
+                    command: commands,
+                    detach: *detach,
+                    detach_keys: detach_keys.as_deref(),
+                    env: _env,
+                    env_file: _env_file,
+                    interactive: *interactive,
+                    privileged: *privileged,
+                    user: user.as_deref(),
+                    workdir: workdir.as_deref(),
+                }
+            }
+            Self::Images {
+                all,
+                digest,
+                filter,
+                format,
+                no_trunc,
+                quiet,
+            } => {
+                let _filter: Option<&str> = match filter {
+                    Some(f) => Some(f),
+                    None => None,
+                };
+
+                let _format: Option<&str> = match format {
+                    Some(f) => Some(f),
+                    None => None,
+                };
+
+                InternalCommand::Images {
+                    all: *all,
+                    digest: *digest,
+                    filter: _filter,
+                    format: _format,
+                    no_trunc: *no_trunc,
+                    quiet: *quiet,
+                }
+            }
+            Self::Logs {
+                container_id,
+                details,
+                follow,
+                since,
+                tail,
+                timestamps,
+                until,
+            } => {
+                let _since: Option<&str> = match since {
+                    Some(s) => Some(s),
+                    None => None,
+                };
+
+                let _tail: Option<&str> = match tail {
+                    Some(t) => Some(t),
+                    None => None,
+                };
+
+                let _until: Option<&str> = match until {
+                    Some(t) => Some(t),
+                    None => None,
+                };
+
+                InternalCommand::Logs {
+                    container_id: &container_id,
+                    details: *details,
+                    follow: *follow,
+                    since: _since,
+                    tail: _tail,
+                    timestamps: *timestamps,
+                    until: _until,
+                }
+            }
+            Self::Ps {
+                all,
+                filter,
+                format,
+                last,
+                latests,
+                no_trunc,
+                quiet,
+                size,
+            } => {
+                let _filter: Option<&str> = match filter {
+                    Some(t) => Some(t),
+                    None => None,
+                };
+
+                let _format: Option<&str> = match format {
+                    Some(t) => Some(t),
+                    None => None,
+                };
+
+                InternalCommand::Ps {
+                    all: *all,
+                    filter: _filter,
+                    format: _format,
+                    last: *last,
+                    latests: *latests,
+                    no_trunc: *no_trunc,
+                    quiet: *quiet,
+                    size: *size,
+                }
+            }
+            Self::Restart { time, container_id } => {
+                let _time: Option<&str> = match time {
+                    Some(t) => Some(t),
+                    None => None,
+                };
+
+                let mut _container_id: Vec<&str> = vec![];
+
+                for cont in container_id {
+                    _container_id.push(cont)
+                }
+
+                InternalCommand::Restart {
+                    time: _time,
+                    container_id: _container_id,
+                }
+            }
+            Self::Rm {
+                container_id,
+                force,
+                volumes,
+            } => {
+                let mut _container_id: Vec<&str> = vec![];
+
+                for cont in container_id {
+                    _container_id.push(cont)
+                }
+                InternalCommand::Rm {
+                    container_id: _container_id,
+                    force: *force,
+                    volumes: *volumes,
+                }
+            }
+            Self::Start {
+                attach,
+                container_id,
+            } => {
+                // let mut _container_id: Vec<&str> = vec![];
+                //
+                // for cont in container_id {
+                //     _container_id.push(cont)
+                // }
+
+                InternalCommand::Start {
+                    attach: *attach,
+                    container_id,
+                }
+            }
+            Self::Stop { container_id } => {
+                //
+                // let mut _container_id: Vec<&str> = vec![];
+                //
+                // for cont in container_id {
+                //     _container_id.push(cont)
+                // }
+                InternalCommand::Stop { container_id }
+            }
+            Self::System(s) => InternalCommand::System(s.clone()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub enum InternalCommand<'a> {
+    /// Execute a command on a given container unless 2 or more containers are found on remote nodes
+    Exec {
+        /// Container name or id
+        container_id: &'a str,
+
+        /// Command that should be ran on the given container
+        command: Vec<&'a str>,
+
+        /// Detached mode: run command in the background
+        detach: bool,
+
+        /// Override the key sequence for detaching a container
+        detach_keys: Option<&'a str>,
+
+        /// Set environment variables
+        env: Option<Vec<&'a str>>,
+
+        /// Read in a file of environment variables
+        env_file: Option<Vec<&'a str>>,
+
+        /// Keep STDIN open even if not attached
+        interactive: bool,
+
+        /// Give extended privileges to the command
+        privileged: bool,
+
+        /// Username or UID (format: <name|uid>[:<group|gid>])
+        user: Option<&'a str>,
+
+        /// Working directory inside the container
+        workdir: Option<&'a str>,
+    },
+
+    /// List all images on remote nodes
+    Images {
+        /// Show all images (default hides intermediate images)
+        all: bool,
+
+        /// Show digests
+        digest: bool,
+
+        /// Filter output based on conditions provided
+        filter: Option<&'a str>,
+
+        /// Pretty-print images using a Go template
+        format: Option<&'a str>,
+
+        /// Don't truncate output
+        no_trunc: bool,
+
+        /// Only show image IDs
+        quiet: bool,
+    },
+
+    /// Gets the logs of a given container unless 2 or more containers are found on remote nodes
+    Logs {
+        /// Container name or id
+        container_id: &'a str,
+
+        /// Show extra details provided to logs
+        details: bool,
+
+        /// Follow the log output
+        follow: bool,
+
+        /// Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+        since: Option<&'a str>,
+
+        /// Number of lines to show from the end of the logs (default "all")
+        tail: Option<&'a str>,
+
+        /// Show timestamps
+        timestamps: bool,
+
+        /// Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+        until: Option<&'a str>,
+    },
+
+    /// Lists all containers on remote nodes
+    Ps {
+        /// Show all containers (default shows just running)
+        all: bool,
+
+        /// Filter output based on conditions provided
+        filter: Option<&'a str>,
+
+        /// Pretty-print containers using a Go template
+        format: Option<&'a str>,
+
+        /// Show n last created containers (includes all states) (default -1)
+        last: bool,
+
+        /// Show the latest created container (includes all states)
+        latests: bool,
+
+        /// Don't truncate output
+        no_trunc: bool,
+
+        /// Only display container IDs
+        quiet: bool,
+
+        /// Display total file sizes
+        size: bool,
+    },
+
+    /// Restart one or more containers on remote nodes
+    Restart {
+        /// Seconds to wait for stop before killing the container (default 10)
+        time: Option<&'a str>,
+
+        /// Container name or id
+        container_id: Vec<&'a str>,
+    },
+
+    /// Remove one or more containers
+    Rm {
+        /// Container name or id
+        container_id: Vec<&'a str>,
+
+        /// Force the removal of a running container (uses SIGKILL)
+        force: bool,
+
+        /// Remove anonymous volumes associated with the container
+        volumes: bool,
+    },
+
+    /// Starts a given container unless 2 or more containers are found on remote nodes
+    Start {
+        /// Attach STDOUT/STDERR and forward signals
+        attach: bool,
+
+        /// Container name or id
+        container_id: &'a str,
+    },
+
+    /// Stops a given container unless 2 or more containers are found on remote nodes
+    Stop {
+        /// Container name or id
+        container_id: &'a str,
+    },
+
+    /// Manage Docker
+    System(System),
+}

--- a/src/cli/flags.rs
+++ b/src/cli/flags.rs
@@ -11,10 +11,10 @@ impl<'a> LogsFlags<'a> {
     pub fn new(
         details: bool,
         follow: bool,
-        since: &'a Option<String>,
-        tail: &'a Option<String>,
+        since: &'a Option<&'a str>,
+        tail: &'a Option<&'a str>,
         timestamps: bool,
-        until: &'a Option<String>,
+        until: &'a Option<&'a str>,
     ) -> Self {
         let _since: &str = match since {
             Some(since) => since,
@@ -76,8 +76,8 @@ impl<'a> LogsFlags<'a> {
 pub struct ExecFlags<'a> {
     pub detach: bool,
     pub detach_keys: &'a str,
-    pub env: Vec<String>,
-    pub env_file: Vec<String>,
+    pub env: Vec<&'a str>,
+    pub env_file: Vec<&'a str>,
     pub interactive: bool,
     pub privileged: bool,
     //pub tty: bool,
@@ -89,14 +89,14 @@ impl<'a> ExecFlags<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         detach: bool,
-        detach_keys: &'a Option<String>,
-        env: Option<Vec<String>>,
-        env_file: Option<Vec<String>>,
+        detach_keys: &'a Option<&str>,
+        env: Option<Vec<&'a str>>,
+        env_file: Option<Vec<&'a str>>,
         interactive: bool,
         privileged: bool,
         //tty: bool,
-        user: &'a Option<String>,
-        workdir: &'a Option<String>,
+        user: &'a Option<&'a str>,
+        workdir: &'a Option<&'a str>,
     ) -> Self {
         let detach_keys = match &detach_keys {
             Some(d) => d,
@@ -198,8 +198,8 @@ impl<'a> ImagesFlags<'a> {
     pub fn new(
         all: bool,
         digest: bool,
-        filter: &'a Option<String>,
-        format: &'a Option<String>,
+        filter: &'a Option<&'a str>,
+        format: &'a Option<&'a str>,
         no_trunc: bool,
         quiet: bool,
     ) -> Self {
@@ -270,8 +270,8 @@ pub struct PsFlags<'a> {
 impl<'a> PsFlags<'a> {
     pub fn new(
         all: bool,
-        filter: &'a Option<String>,
-        format: &'a Option<String>,
+        filter: &'a Option<&'a str>,
+        format: &'a Option<&'a str>,
         last: bool,
         latests: bool,
         no_trunc: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
 mod app;
 pub mod flags;
 
-pub use app::{App, Command, System, SystemCommand};
+pub use app::{App, Command, InternalCommand, System, SystemCommand};

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::cli::flags::{ExecFlags, ImagesFlags, LogsFlags, PsFlags, RmFlags};
-use crate::cli::Command;
+use crate::cli::InternalCommand;
 use crate::utility::command;
 
 use regex::Regex;
@@ -65,7 +65,7 @@ impl Node {
 
     pub async fn run_command(
         &self,
-        command: Command,
+        command: InternalCommand<'_>,
         sudo: bool,
         identity_file: Option<&str>,
     ) -> Result<String, NodeError> {
@@ -82,11 +82,7 @@ impl Node {
         };
 
         match command {
-            Command::Completion { shell: _ } => {
-                // This command should not lead to any activity
-                unreachable!()
-            }
-            Command::Exec {
+            InternalCommand::Exec {
                 container_id,
                 command,
                 detach,
@@ -115,7 +111,7 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Images {
+            InternalCommand::Images {
                 all,
                 digest,
                 filter,
@@ -130,7 +126,7 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Logs {
+            InternalCommand::Logs {
                 container_id,
                 details,
                 follow,
@@ -147,7 +143,7 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Ps {
+            InternalCommand::Ps {
                 all,
                 filter,
                 format,
@@ -164,14 +160,14 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Restart { time, container_id } => {
+            InternalCommand::Restart { time, container_id } => {
                 match command::run_restart(&self.address, session, sudo, time, &container_id).await
                 {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Rm {
+            InternalCommand::Rm {
                 container_id,
                 force,
                 volumes,
@@ -182,7 +178,7 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Start {
+            InternalCommand::Start {
                 container_id,
                 attach,
             } => {
@@ -192,13 +188,13 @@ impl Node {
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::Stop { container_id } => {
+            InternalCommand::Stop { container_id } => {
                 match command::run_stop(&self.address, session, sudo, &container_id).await {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),
                 }
             }
-            Command::System(command) => {
+            InternalCommand::System(command) => {
                 match command::run_system(&self.address, session, sudo, command).await {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,10 @@ pub async fn run() {
                 cli::Command::Images { .. } => parse = true,
                 _ => (),
             }
-            for word in utility::run_command(_cli.command, _cli.sudo, regex, identity_file).await {
+            let internal_command = _cli.command.internal_reference_command();
+            for word in
+                utility::run_command(internal_command, _cli.sudo, regex, identity_file).await
+            {
                 match word {
                     Ok(s) => result.push_str(&s),
                     Err(e) => {

--- a/src/utility/command.rs
+++ b/src/utility/command.rs
@@ -6,7 +6,7 @@ pub async fn run_exec(
     session: openssh::Session,
     container_id: &str,
     sudo: bool,
-    command: Vec<String>,
+    command: Vec<&str>,
     //args: Option<Vec<String>>,
     flags: ExecFlags<'_>,
 ) -> Result<String, openssh::Error> {
@@ -209,8 +209,8 @@ pub async fn run_restart(
     hostname: &str,
     session: openssh::Session,
     sudo: bool,
-    time: Option<String>,
-    container_id: &[String],
+    time: Option<&str>,
+    container_id: &[&str],
 ) -> Result<String, openssh::Error> {
     let mut command = vec!["restart"];
 
@@ -256,7 +256,7 @@ pub async fn run_rm(
     hostname: &str,
     session: openssh::Session,
     sudo: bool,
-    container_id: &Vec<String>,
+    container_id: &Vec<&str>,
     flags: RmFlags,
 ) -> Result<String, openssh::Error> {
     let mut command = vec!["rm"];

--- a/src/utility/other.rs
+++ b/src/utility/other.rs
@@ -1,6 +1,6 @@
 use crate::constants;
 
-use crate::cli::Command;
+use crate::cli::InternalCommand;
 use crate::client::{Client, NodeError};
 
 use futures::{stream, StreamExt};
@@ -9,7 +9,7 @@ use futures::{stream, StreamExt};
 /// Vec of `Container`.
 pub async fn find_containers(
     client: Client,
-    container_ids: &[String],
+    container_ids: &[&str],
     sudo: bool,
     all: bool,
     identity_file: Option<&str>,
@@ -21,7 +21,7 @@ pub async fn find_containers(
             .map(|(hostname, node)| async move {
                 match node
                     .run_command(
-                        Command::Ps {
+                        InternalCommand::Ps {
                             all,
                             filter: None,
                             format: None,


### PR DESCRIPTION
This pr changes the `run_command` function so it takes a different type than the cli command gets passed in so there is a disconnect in their implementations. It does this by adding a new type `InternalCommand` that acts like a view into the `Command` enum.