### PR TITLE
Updated start and stop command to accept multiple container_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-[[#61]](https://github.com/MitchellBerend/docker-manager/pull/61) Added support multiple container_ids for the start and stop commands
+[[#62]](https://github.com/MitchellBerend/docker-manager/pull/62) Added support multiple container_ids for the start and stop commands
 
 [[#60]](https://github.com/MitchellBerend/docker-manager/pull/60) Added support for removing multiple containers on multiple nodes at once
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[[#61]](https://github.com/MitchellBerend/docker-manager/pull/61) Added support multiple container_ids for the start and stop commands
+
 [[#60]](https://github.com/MitchellBerend/docker-manager/pull/60) Added support for removing multiple containers on multiple nodes at once
 
 [[#57]](https://github.com/MitchellBerend/docker-manager/pull/57) Added support for restarting multiple containers on multiple nodes at once

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ to support all docker commands on remote nodes.
 | PS       |                               |
 | RESTART  | Multiple containers supported |
 | RM       | Multiple containers supported |
-| START    |                               |
-| STOP     |                               |
+| START    | Multiple containers supported |
+| STOP     | Multiple containers supported |
 | SYSTEM   |                               |
 
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -187,20 +187,20 @@ pub enum Command {
         volumes: bool,
     },
 
-    /// Starts a given container unless 2 or more containers are found on remote nodes
+    /// Starts one or more given containers
     Start {
         /// Attach STDOUT/STDERR and forward signals
         #[arg(short, long)]
         attach: bool,
 
         /// Container name or id
-        container_id: String,
+        container_id: Vec<String>,
     },
 
-    /// Stops a given container unless 2 or more containers are found on remote nodes
+    /// Stops one or more given containers
     Stop {
         /// Container name or id
-        container_id: String,
+        container_id: Vec<String>,
     },
 
     /// Manage Docker
@@ -325,7 +325,7 @@ impl Command {
                 };
 
                 InternalCommand::Exec {
-                    container_id: &container_id,
+                    container_id,
                     command: commands,
                     detach: *detach,
                     detach_keys: detach_keys.as_deref(),
@@ -389,7 +389,7 @@ impl Command {
                 };
 
                 InternalCommand::Logs {
-                    container_id: &container_id,
+                    container_id,
                     details: *details,
                     follow: *follow,
                     since: _since,
@@ -466,25 +466,27 @@ impl Command {
                 attach,
                 container_id,
             } => {
-                // let mut _container_id: Vec<&str> = vec![];
-                //
-                // for cont in container_id {
-                //     _container_id.push(cont)
-                // }
+                let mut _container_id: Vec<&str> = vec![];
+
+                for cont in container_id {
+                    _container_id.push(cont)
+                }
 
                 InternalCommand::Start {
                     attach: *attach,
-                    container_id,
+                    container_id: _container_id,
                 }
             }
             Self::Stop { container_id } => {
-                //
-                // let mut _container_id: Vec<&str> = vec![];
-                //
-                // for cont in container_id {
-                //     _container_id.push(cont)
-                // }
-                InternalCommand::Stop { container_id }
+                let mut _container_id: Vec<&str> = vec![];
+
+                for cont in container_id {
+                    _container_id.push(cont)
+                }
+
+                InternalCommand::Stop {
+                    container_id: _container_id,
+                }
             }
             Self::System(s) => InternalCommand::System(s.clone()),
             _ => unreachable!(),
@@ -625,13 +627,13 @@ pub enum InternalCommand<'a> {
         attach: bool,
 
         /// Container name or id
-        container_id: &'a str,
+        container_id: Vec<&'a str>,
     },
 
     /// Stops a given container unless 2 or more containers are found on remote nodes
     Stop {
         /// Container name or id
-        container_id: &'a str,
+        container_id: Vec<&'a str>,
     },
 
     /// Manage Docker

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -104,7 +104,7 @@ impl Node {
                     &user,
                     &workdir,
                 );
-                match command::run_exec(&self.address, session, &container_id, sudo, command, flags)
+                match command::run_exec(&self.address, session, container_id, sudo, command, flags)
                     .await
                 {
                     Ok(result) => Ok(result),
@@ -137,7 +137,7 @@ impl Node {
             } => {
                 let flags = LogsFlags::new(details, follow, &since, &tail, timestamps, &until);
 
-                match command::run_logs(&self.address, session, &container_id, sudo, flags).await {
+                match command::run_logs(&self.address, session, container_id, sudo, flags).await {
                     //, follow).await {
                     Ok(result) => Ok(result),
                     Err(e) => Err(NodeError::SessionError(self.address.clone(), e)),

--- a/src/utility/command.rs
+++ b/src/utility/command.rs
@@ -262,7 +262,7 @@ pub async fn run_rm(
     let mut command = vec!["rm"];
 
     for container in container_id {
-        command.push(&container);
+        command.push(container);
     }
 
     for flag in flags.flags() {
@@ -299,10 +299,13 @@ pub async fn run_start(
     hostname: &str,
     session: openssh::Session,
     sudo: bool,
-    container_id: &str,
+    container_id: &Vec<&str>,
     attatch: bool,
 ) -> Result<String, openssh::Error> {
-    let mut command = vec!["start", container_id];
+    let mut command = vec!["start"];
+    for container in container_id {
+        command.push(container);
+    }
 
     if attatch {
         command.push("-a");
@@ -338,9 +341,12 @@ pub async fn run_stop(
     hostname: &str,
     session: openssh::Session,
     sudo: bool,
-    container_id: &str,
+    container_id: &Vec<&str>,
 ) -> Result<String, openssh::Error> {
-    let command = vec!["stop", container_id];
+    let mut command = vec!["stop"];
+    for container in container_id {
+        command.push(container);
+    }
 
     let _output = match sudo {
         true => {

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -361,11 +361,44 @@ pub async fn run_command<'a>(
                     }
                 }
                 _ => {
-                    let nodes = node_containers
-                        .iter()
-                        .map(|result| result.id().to_string())
-                        .collect::<Vec<String>>();
-                    vec![Err(CommandError::MutlipleNodesFound(nodes))]
+                    let bodies = stream::iter(node_containers)
+                        .map(|container| async move {
+                            let node = Node::new(container.node().to_string());
+                            match node
+                                .run_command(
+                                    InternalCommand::Start {
+                                        container_id: vec![container.id()],
+                                        attach,
+                                    },
+                                    sudo,
+                                    identity_file,
+                                )
+                                .await
+                            {
+                                Ok(result) => (container.hostname().to_string(), Ok(result)),
+                                Err(e) => (container.hostname().to_string(), Err(e)),
+                            }
+                        })
+                        .buffer_unordered(constants::CONCURRENT_REQUESTS);
+
+                    let _rv = bodies
+                        .collect::<Vec<(String, Result<String, NodeError>)>>()
+                        .await;
+
+                    let mut rv = vec![];
+
+                    for (_, res) in _rv {
+                        match res {
+                            Ok(s) => rv.push(Ok(s)),
+                            Err(e) => rv.push(Err(CommandError::NodeError(e))),
+                        }
+                    }
+                    rv
+                    // let nodes = node_containers
+                    //     .iter()
+                    //     .map(|result| result.id().to_string())
+                    //     .collect::<Vec<String>>();
+                    // vec![Err(CommandError::MutlipleNodesFound(nodes))]
                 }
             }
         }
@@ -390,11 +423,38 @@ pub async fn run_command<'a>(
                     }
                 }
                 _ => {
-                    let nodes = node_containers
-                        .iter()
-                        .map(|result| result.id().to_string())
-                        .collect::<Vec<String>>();
-                    vec![Err(CommandError::MutlipleNodesFound(nodes))]
+                    let bodies = stream::iter(node_containers)
+                        .map(|container| async move {
+                            let node = Node::new(container.node().to_string());
+                            match node
+                                .run_command(
+                                    InternalCommand::Stop {
+                                        container_id: vec![container.id()],
+                                    },
+                                    sudo,
+                                    identity_file,
+                                )
+                                .await
+                            {
+                                Ok(result) => (container.hostname().to_string(), Ok(result)),
+                                Err(e) => (container.hostname().to_string(), Err(e)),
+                            }
+                        })
+                        .buffer_unordered(constants::CONCURRENT_REQUESTS);
+
+                    let _rv = bodies
+                        .collect::<Vec<(String, Result<String, NodeError>)>>()
+                        .await;
+
+                    let mut rv = vec![];
+
+                    for (_, res) in _rv {
+                        match res {
+                            Ok(s) => rv.push(Ok(s)),
+                            Err(e) => rv.push(Err(CommandError::NodeError(e))),
+                        }
+                    }
+                    rv
                 }
             }
         }

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -1,5 +1,5 @@
-use futures::{stream, StreamExt};
 use crate::constants;
+use futures::{stream, StreamExt};
 
 use crate::cli::InternalCommand;
 use crate::client::{Client, Node, NodeError};
@@ -225,23 +225,21 @@ pub async fn run_command<'a>(
                 }
                 _ => {
                     let bodies = stream::iter(node_containers)
-                        .map(|container| {
-                            async move {
-                                let node = Node::new(container.node().to_string());
-                                match node
-                                    .run_command(
-                                        InternalCommand::Restart {
-                                            time,
-                                            container_id: vec![container.id()],
-                                        },
-                                        sudo,
-                                        identity_file,
-                                    )
-                                    .await
-                                {
-                                    Ok(result) => (container.hostname().to_string(), Ok(result)),
-                                    Err(e) => (container.hostname().to_string(), Err(e)),
-                                }
+                        .map(|container| async move {
+                            let node = Node::new(container.node().to_string());
+                            match node
+                                .run_command(
+                                    InternalCommand::Restart {
+                                        time,
+                                        container_id: vec![container.id()],
+                                    },
+                                    sudo,
+                                    identity_file,
+                                )
+                                .await
+                            {
+                                Ok(result) => (container.hostname().to_string(), Ok(result)),
+                                Err(e) => (container.hostname().to_string(), Err(e)),
                             }
                         })
                         .buffer_unordered(constants::CONCURRENT_REQUESTS);

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -1,5 +1,4 @@
 use futures::{stream, StreamExt};
-
 use crate::constants;
 
 use crate::cli::InternalCommand;
@@ -227,13 +226,12 @@ pub async fn run_command<'a>(
                 _ => {
                     let bodies = stream::iter(node_containers)
                         .map(|container| {
-                            let async_time = time.clone();
                             async move {
                                 let node = Node::new(container.node().to_string());
                                 match node
                                     .run_command(
                                         InternalCommand::Restart {
-                                            time: async_time,
+                                            time,
                                             container_id: vec![container.id()],
                                         },
                                         sudo,
@@ -339,11 +337,11 @@ pub async fn run_command<'a>(
             attach,
         } => {
             let node_containers: Vec<Container> =
-                find_containers(client, &[container_id.clone()], sudo, true, identity_file).await;
+                find_containers(client, &container_id, sudo, true, identity_file).await;
 
             match node_containers.len() {
                 0 => {
-                    vec![Err(CommandError::NoNodesFound(container_id))]
+                    vec![Err(CommandError::NoMultipleNodesFound(container_id))]
                 }
                 1 => {
                     // unwrap is safe here since we .unwrap()check if there is exactly 1 element
@@ -375,11 +373,11 @@ pub async fn run_command<'a>(
         }
         InternalCommand::Stop { container_id } => {
             let node_containers: Vec<Container> =
-                find_containers(client, &[container_id.clone()], sudo, false, identity_file).await;
+                find_containers(client, &container_id, sudo, false, identity_file).await;
 
             match node_containers.len() {
                 0 => {
-                    vec![Err(CommandError::NoNodesFound(container_id))]
+                    vec![Err(CommandError::NoMultipleNodesFound(container_id))]
                 }
                 1 => {
                     // unwrap is safe here since we .unwrap()check if there is exactly 1 element


### PR DESCRIPTION
Resolves #60

This pr adds multiple container id support to the `docker start` and `docker stop` commands.


### Additional tasks

- [x] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
