### PR TITLE
Bumped versions to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+
+v0.0.8
+---
+
+## Added
+
 [[#62]](https://github.com/MitchellBerend/docker-manager/pull/62) Added support multiple container_ids for the start and stop commands
 
 [[#60]](https://github.com/MitchellBerend/docker-manager/pull/60) Added support for removing multiple containers on multiple nodes at once

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-manager"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pr bumps the versions and closes the `CHANGELOG.md` 0.0.7 section

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
