### PR TITLE
Merged all found containers on the same node in the same `Container`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+[[#67]](https://github.com/MitchellBerend/docker-manager/pull/67) Updated the `find_containers` function to return a `Container` object that holds all found containers
+
 
 v0.0.8
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "docker-manager"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "clap",
  "clap_complete",

--- a/src/utility/other.rs
+++ b/src/utility/other.rs
@@ -17,7 +17,6 @@ pub async fn find_containers(
     identity_file: Option<&str>,
 ) -> Vec<Container> {
     let mut rv = vec![];
-
     let mut inter: HashMap<String, Vec<String>> = HashMap::new();
 
     for container_id in container_ids {

--- a/src/utility/other.rs
+++ b/src/utility/other.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::constants;
 
 use crate::cli::InternalCommand;
@@ -15,6 +17,8 @@ pub async fn find_containers(
     identity_file: Option<&str>,
 ) -> Vec<Container> {
     let mut rv = vec![];
+
+    let mut inter: HashMap<String, Vec<String>> = HashMap::new();
 
     for container_id in container_ids {
         let bodies = stream::iter(client.nodes_info())
@@ -50,7 +54,24 @@ pub async fn find_containers(
             .collect::<Vec<(String, String, String)>>();
 
         for container in containers {
-            rv.push(Container::new(container.0, container.1, container.2))
+            let hostname = container.0;
+            let container_id = container.2;
+
+            if let Some(host_containers) = inter.get_mut(&hostname) {
+                host_containers.push(container_id);
+            } else {
+                inter.insert(hostname, vec![container_id]);
+            }
+        }
+    }
+
+    for (hostname, containers) in inter.iter() {
+        if !containers.is_empty() {
+            rv.push(Container::new(
+                hostname.to_string(),
+                hostname.to_string(),
+                containers.to_vec(),
+            ))
         }
     }
 
@@ -78,6 +99,7 @@ fn node_filter_map(
     }
 }
 
+#[derive(Debug)]
 pub struct FindContainerResult {
     containers: Vec<Container>,
 }
@@ -90,14 +112,15 @@ impl Iterator for FindContainerResult {
     }
 }
 
+#[derive(Debug)]
 pub struct Container {
     hostname: String,
     node: String,
-    container_id: String,
+    container_id: Vec<String>,
 }
 
 impl Container {
-    fn new(hostname: String, node: String, container_id: String) -> Self {
+    fn new(hostname: String, node: String, container_id: Vec<String>) -> Self {
         Self {
             hostname,
             node,
@@ -113,8 +136,14 @@ impl Container {
         &self.node
     }
 
-    pub fn id(&self) -> &str {
-        &self.container_id
+    pub fn id(&self) -> Vec<&str> {
+        let mut rv: Vec<&str> = vec![];
+
+        for container in &self.container_id {
+            rv.push(container);
+        }
+
+        rv
     }
 }
 

--- a/src/utility/run.rs
+++ b/src/utility/run.rs
@@ -69,7 +69,7 @@ pub async fn run_command<'a>(
                 _ => {
                     let nodes = node_containers
                         .iter()
-                        .map(|result| result.id().to_string())
+                        .map(|result| result.id().join(" "))
                         .collect::<Vec<String>>();
                     vec![Err(CommandError::MutlipleNodesFound(nodes))]
                 }
@@ -149,7 +149,7 @@ pub async fn run_command<'a>(
                 _ => {
                     let nodes = node_containers
                         .iter()
-                        .map(|result| result.id().to_string())
+                        .map(|result| result.id().join(" "))
                         .collect::<Vec<String>>();
                     vec![Err(CommandError::MutlipleNodesFound(nodes))]
                 }
@@ -207,7 +207,7 @@ pub async fn run_command<'a>(
                                 .run_command(
                                     InternalCommand::Restart {
                                         time,
-                                        container_id: vec![container.id()],
+                                        container_id: container.id(),
                                     },
                                     sudo,
                                     identity_file,
@@ -255,7 +255,7 @@ pub async fn run_command<'a>(
                             match node
                                 .run_command(
                                     InternalCommand::Rm {
-                                        container_id: vec![container.id()],
+                                        container_id: container.id(),
                                         force,
                                         volumes,
                                     },
@@ -304,7 +304,7 @@ pub async fn run_command<'a>(
                             match node
                                 .run_command(
                                     InternalCommand::Start {
-                                        container_id: vec![container.id()],
+                                        container_id: container.id(),
                                         attach,
                                     },
                                     sudo,
@@ -349,7 +349,7 @@ pub async fn run_command<'a>(
                             match node
                                 .run_command(
                                     InternalCommand::Stop {
-                                        container_id: vec![container.id()],
+                                        container_id: container.id(),
                                     },
                                     sudo,
                                     identity_file,


### PR DESCRIPTION
Resolves #66 
This pr updates the `find_containers` function to contain all the container_ids found on a single node so they can be executed on on a single ssh connection. It also updates the `Container` struct to hold a `Vec<String>` instead of a `String` on it's container_id field.

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
